### PR TITLE
Rearrange-cluster-layout

### DIFF
--- a/components/ProgramEditor.tsx
+++ b/components/ProgramEditor.tsx
@@ -14,7 +14,7 @@ export default function ProgramEditor() {
   useEffect(() => {
     setProgram(makeInitialProgram());
   }, []);
-  const { blockLayouts, lineConnectionLayouts } = useMemo(
+  const { blockLayouts, lineConnectionLayouts, layerIntervals } = useMemo(
     () => calculateProgramLayout(program),
     [program]
   );
@@ -86,6 +86,19 @@ export default function ProgramEditor() {
         }
       }}
     >
+      <g>
+        {/* This is to temporarily visualize the layer intervals, for debugging. */}
+        {layerIntervals.map(({ left, size }, index) => (
+          <rect
+            key={index}
+            x={-300}
+            width={600}
+            y={left}
+            height={size}
+            opacity={0.1}
+          />
+        ))}
+      </g>
       {clusterRootBlockIds
         .flatMap((clusterRootBlockId) =>
           getDescendantsTopologicallySorted(

--- a/components/ProgramEditor.tsx
+++ b/components/ProgramEditor.tsx
@@ -244,6 +244,7 @@ export default function ProgramEditor() {
               }
               stroke="black"
               strokeWidth={4}
+              strokeLinecap="round"
               opacity={0.2}
             />
           );
@@ -273,6 +274,7 @@ export default function ProgramEditor() {
               y2={y}
               stroke="black"
               strokeWidth={4}
+              strokeLinecap="round"
               opacity={0.2}
             />
           );

--- a/components/ProgramEditor.tsx
+++ b/components/ProgramEditor.tsx
@@ -161,17 +161,21 @@ export default function ProgramEditor() {
           };
 
           return (
-            <g key={index}>
+            <motion.g
+              key={index}
+              animate={{
+                opacity:
+                  isDraggingDependencyBlock || isDraggingDependentBlock
+                    ? 0.25
+                    : 1,
+              }}
+            >
               <motion.line
                 animate={{
                   x1: draggedStartPoint.x,
                   y1: draggedStartPoint.y,
                   x2: draggedEndPoint.x,
                   y2: draggedEndPoint.y,
-                  opacity:
-                    isDraggingDependencyBlock || isDraggingDependentBlock
-                      ? 0.25
-                      : 1,
                 }}
                 transition={{
                   ...(isDraggingDependencyBlock
@@ -188,7 +192,6 @@ export default function ProgramEditor() {
                 animate={{
                   cx: draggedEndPoint.x,
                   cy: draggedEndPoint.y,
-                  opacity: isDraggingDependentBlock ? 0.5 : 1,
                 }}
                 transition={{
                   ...(isDraggingDependentBlock
@@ -198,7 +201,7 @@ export default function ProgramEditor() {
                 r={5}
                 fill={colors.black}
               />
-            </g>
+            </motion.g>
           );
         }
       )}

--- a/logic/calculateProgramLayout.ts
+++ b/logic/calculateProgramLayout.ts
@@ -184,6 +184,10 @@ export default function calculateProgramLayout(program: Program): {
   for (const blockId of Object.keys(program.blocks)) {
     blockLayouts[blockId] = {
       topLeft: blockTopLefts[blockId],
+      bottomRight: {
+        x: blockTopLefts[blockId].x + blockSizes[blockId].width,
+        y: blockTopLefts[blockId].y + blockSizes[blockId].height,
+      },
       center: {
         x: blockTopLefts[blockId].x + blockSizes[blockId].width / 2,
         y: blockTopLefts[blockId].y + blockSizes[blockId].height / 2,

--- a/logic/calculateProgramLayout.ts
+++ b/logic/calculateProgramLayout.ts
@@ -2,7 +2,9 @@ import BlockLayout from "@/model/BlockLayout";
 import { Program } from "@/model/Program";
 import getDescendantsTopologicallySorted from "./graph/getDescendantsTopologicallySorted";
 import { getDependenciesOfBlock, getLayoutCalculator } from "@/model/Block";
-import layoutIntervalsInSeries from "./geometry/layoutIntervalsInSeries";
+import layoutIntervalsInSeries, {
+  Interval,
+} from "./geometry/layoutIntervalsInSeries";
 import programToNestedDependencyGraph from "./programToNestedDependencyGraph";
 import findRoots from "./graph/findRoots";
 
@@ -50,11 +52,14 @@ function calculateBlockSizesAndOffsets(
   return { blockSizes, blockDependenciesOffsets };
 }
 
-function calculateClusterRootBlockTopLefts(
+function calculateClusterRootBlockTopLeftsAndLayerIntervals(
   program: Program,
   clusters: { [id: string]: string[] },
   blockSizes: { [id: string]: { width: number; height: number } }
-): { [id: string]: { x: number; y: number } } {
+): {
+  clusterRootBlockTopLefts: { [id: string]: { x: number; y: number } };
+  layerIntervals: Interval[];
+} {
   const clusterRootBlockTopLefts: { [id: string]: { x: number; y: number } } =
     {};
 
@@ -94,7 +99,7 @@ function calculateClusterRootBlockTopLefts(
     }
   }
 
-  return clusterRootBlockTopLefts;
+  return { clusterRootBlockTopLefts, layerIntervals };
 }
 
 interface LineConnectionLayout {
@@ -156,15 +161,17 @@ export default function calculateProgramLayout(program: Program): {
     [id: string]: BlockLayout;
   };
   lineConnectionLayouts: LineConnectionLayout[];
+  layerIntervals: Interval[];
 } {
   const clusters = getClusters(program);
   const { blockSizes, blockDependenciesOffsets } =
     calculateBlockSizesAndOffsets(program, clusters);
-  const clusterRootBlockTopLefts = calculateClusterRootBlockTopLefts(
-    program,
-    clusters,
-    blockSizes
-  );
+  const { clusterRootBlockTopLefts, layerIntervals } =
+    calculateClusterRootBlockTopLeftsAndLayerIntervals(
+      program,
+      clusters,
+      blockSizes
+    );
   const { blockTopLefts, lineConnectionLayouts } =
     calculateNestedBlockTopLeftsAndLineConnectionLayouts(
       program,
@@ -189,5 +196,5 @@ export default function calculateProgramLayout(program: Program): {
     };
   }
 
-  return { blockLayouts, lineConnectionLayouts };
+  return { blockLayouts, lineConnectionLayouts, layerIntervals };
 }

--- a/logic/geometry/layoutIntervalsInSeries.ts
+++ b/logic/geometry/layoutIntervalsInSeries.ts
@@ -1,3 +1,10 @@
+export interface Interval {
+  left: number;
+  center: number;
+  right: number;
+  size: number;
+}
+
 /**
  * Given a series of intervals, lay them out in a row, with a given gap between
  * each interval. If padding is specified, the first and last intervals will be
@@ -14,7 +21,7 @@ export default function layoutIntervalsInSeries(
   padding: number | undefined = undefined,
   center: boolean = true
 ): {
-  intervals: { left: number; center: number; right: number; size: number }[];
+  intervals: Interval[];
   totalSize: number;
 } {
   if (padding == null) {

--- a/model/BlockLayout.ts
+++ b/model/BlockLayout.ts
@@ -11,6 +11,10 @@ export default interface BlockLayout {
     x: number;
     y: number;
   };
+  bottomRight: {
+    x: number;
+    y: number;
+  };
   size: {
     width: number;
     height: number;


### PR DESCRIPTION
Fixes #93, but not completely. What's missing:

- Layout changes are not constrained such that dependencies must be in higher layers than their dependents.
- Blocks cannot be nested in other blocks via dragging.